### PR TITLE
Allow to specify postgresql-operator storageClass

### DIFF
--- a/charts/geonode/templates/postgres/postgresql-operator.yaml
+++ b/charts/geonode/templates/postgres/postgresql-operator.yaml
@@ -8,6 +8,7 @@ spec:
   teamId: {{ .Release.Name | quote }}
   volume:
     size: {{ .Values.postgres.operator.storageSize }}
+    storageClass: {{ .Values.global.storageClass }}
   numberOfInstances: {{ int .Values.postgres.operator.numberOfInstances }}
   users:
     {{ .Values.postgres.username }}:


### PR DESCRIPTION
## Description

This is needed to specify the custom storageClass to be used for the Postgres data PV.

## Type of Change

Please select the relevant option:

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe)

## Related Issue

If there is an existing issue related to this pull request, please reference it here.

closes #

## Checklist

Please ensure that your pull request meets the following requirements:

- The pull request is limited to one type (docs, feature, bug fix, etc.)
- The pull request is as small as possible. Consider opening multiple pull requests instead of one large one.
- The feature or bug fix has been discussed and documented in an issue beforehand.

## Additional Notes

Any additional information or context regarding the pull request can be provided here.

Thank you for creating this pull request