### PR TITLE
pg operator: replace _ with - in secret name helper

### DIFF
--- a/charts/geonode/templates/_helpers.tpl
+++ b/charts/geonode/templates/_helpers.tpl
@@ -70,7 +70,7 @@ require
 # secret key reference for the password of user:  .Values.postgres.geonode_databasename_and_username
 {{- define "database_geonode_password_secret_key_ref" -}}
 {{- if (eq .Values.postgres.type "operator") -}}
-"{{ .Values.postgres.geonode_databasename_and_username }}.{{ include "postgres_pod_name" . }}.credentials.postgresql.acid.zalan.do"
+"{{ .Values.postgres.geonode_databasename_and_username | replace "_" "-" }}.{{ include "postgres_pod_name" . }}.credentials.postgresql.acid.zalan.do"
 {{- else if and (eq .Values.postgres.type "external") (not .Values.postgres.external.secret.existingSecretName ) -}}
 "{{ .Release.Name }}-geonode-external-secrets"
 {{- else -}}
@@ -81,7 +81,7 @@ require
 # secret key reference for the password of user: .Values.postgres.geodata_databasename_and_username
 {{- define "database_geodata_password_secret_key_ref" -}}
 {{- if (eq .Values.postgres.type "operator") -}}
-"{{ .Values.postgres.geodata_databasename_and_username }}.{{ include "postgres_pod_name" . }}.credentials.postgresql.acid.zalan.do"
+"{{ .Values.postgres.geodata_databasename_and_username | replace "_" "-" }}.{{ include "postgres_pod_name" . }}.credentials.postgresql.acid.zalan.do"
 {{- else if and (eq .Values.postgres.type "external") (not .Values.postgres.external.secret.existingSecretName ) -}}
 "{{ .Release.Name }}-geodata-external-secrets"
 {{- else if .Values.postgres.external.secret.existingSecretName -}}


### PR DESCRIPTION
## Description

If a Postgres user contains a `_`, the created secret will have the occurrences replaced with `-`.
This commit is necessary both to generate the correct secret name and to have the Pod running. An `_` in that value is forbidden and would prevent the Pod from being created.

## Type of Change

Please select the relevant option:

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe)

## Related Issue

If there is an existing issue related to this pull request, please reference it here.

closes #

## Checklist

Please ensure that your pull request meets the following requirements:

- The pull request is limited to one type (docs, feature, bug fix, etc.)
- The pull request is as small as possible. Consider opening multiple pull requests instead of one large one.
- The feature or bug fix has been discussed and documented in an issue beforehand.

## Additional Notes

Any additional information or context regarding the pull request can be provided here.

Thank you for creating this pull request